### PR TITLE
:construction_worker: Fix issues found by go-critic linter

### DIFF
--- a/golyrics.go
+++ b/golyrics.go
@@ -44,7 +44,7 @@ func breakToNewLine(HTML string) string {
 }
 
 func stripeHTMLTags(HTML string) string {
-	regex, _ := regexp.Compile("<[^>]+>")
+	regex := regexp.MustCompile("<[^>]+>")
 	return regex.ReplaceAllString(HTML, "")
 }
 
@@ -78,7 +78,7 @@ func SearchTrack(query string) ([]Track, error) {
 
 	suggestions := []Track{}
 	jsonparser.ArrayEach(data, func(value []byte, _ jsonparser.ValueType, offset int, _ error) {
-		title := string(value[:])
+		title := string(value)
 		trackParts := strings.SplitN(title, ":", 2)
 		if len(trackParts) < 2 {
 			return
@@ -95,6 +95,6 @@ func SearchTrack(query string) ([]Track, error) {
 
 // SearchTrackByArtistAndName searches for tracks
 // using artist and name of the track.
-func SearchTrackByArtistAndName(artist string, name string) ([]Track, error) {
+func SearchTrackByArtistAndName(artist, name string) ([]Track, error) {
 	return SearchTrack(artist + ":" + name)
 }

--- a/golyrics_test.go
+++ b/golyrics_test.go
@@ -247,7 +247,7 @@ func TestTrack_FetchLyrics(t *testing.T) {
 			fields: fields{
 				Artist: "Sandra_Boynton",
 				Name:   "The_Shortest_Song_In_The_Universe",
-				Lyrics: "The shortest song in the universe\nReally isn't much fun\nIt only has one puny verse\n. . . and then it's done!\n",
+				Lyrics: "The shortest song in the universe\nReally isn't much fun\nIt only has one puny verse\n... And then it's done!\n",
 			},
 		},
 	}


### PR DESCRIPTION
```
golyrics.go:98:1: paramTypeCombine: func(artist string, name string) ([]Track, error) could be replaced with func(artist, name string) ([]Track, error)
golyrics.go:81:19: unslice: could simplify value[:] to value
golyrics.go:47:14: regexpMust: for const patterns like "<[^>]+>", use regexp.MustCompile
```